### PR TITLE
feat: add .npmrc file, modify gitignore, and update package.json engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # build output
 dist/
+.vercel/
+.netlify/
+
 # generated types
 .astro/
 
@@ -25,3 +28,6 @@ pnpm-debug.log*
 
 # output log
 output-log.md
+
+# NPMRC file for Development Mode only ('cause Vercel error message: "Detected unsupported "use-node-version" in your ".npmrc"
+.npmrc

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "",
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": "20.10.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
• Added .npmrc file to specify Node.js version 20.12.2 due to Vercel warning about unsupported local Node.js version. This ensures compatibility with Vercel Serverless Functions.
• Added .vercel/ folder to gitignore to prevent build outputs from being committed.
• Updated package.json to include engines field specifying Node.js version 20.10.0 to resolve Vercel build error.
• Added .npmrc to gitignore for development mode only to avoid Vercel build errors

commit-id:9425e060