### PR TITLE
feat: wrap MarkdownPostLayout content with BaseLayout

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,11 +1,15 @@
 ---
+import BaseLayout from "./BaseLayout.astro";
+
 const { frontmatter } = Astro.props;
 ---
 
-<h1>{frontmatter.title}</h1>
-<p>{frontmatter.pubDate.toString().slice(0, 10)}</p>
-<p><em>{frontmatter.description}</em></p>
-<p>Written by: {frontmatter.author}</p>
-<img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+<BaseLayout>
+  <h1>{frontmatter.title}</h1>
+  <p>{frontmatter.pubDate.toString().slice(0, 10)}</p>
+  <p><em>{frontmatter.description}</em></p>
+  <p>Written by: {frontmatter.author}</p>
+  <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
 
-<slot />
+  <slot />
+</BaseLayout>


### PR DESCRIPTION
•  Import `BaseLayout` in `MarkdownPostLayout.astro`
•  Wrap existing content within `BaseLayout` component

Part of Astro Tutorial: Nest your two layouts

commit-id:b01ccd35