### PR TITLE
refactor: optimize tag filtering and post rendering

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,38 +1,35 @@
 ---
+import BlogPost from "../../components/BlogPost.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 export const prerender = true;
 
 export async function getStaticPaths() {
   const allPosts = await Astro.glob("../posts/*.md");
-
-  return [
-    { params: { tag: "astro" }, props: { posts: allPosts } },
-    { params: { tag: "successes" }, props: { posts: allPosts } },
-    { params: { tag: "community" }, props: { posts: allPosts } },
-    { params: { tag: "blogging" }, props: { posts: allPosts } },
-    { params: { tag: "setbacks" }, props: { posts: allPosts } },
-    { params: { tag: "learning-in-public" }, props: { posts: allPosts } },
+  const uniqueTags = [
+    ...new Set(allPosts.map((post) => post.frontmatter.tags).flat()),
   ];
+
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post) =>
+      post.frontmatter.tags?.includes(tag)
+    );
+    return {
+      params: { tag },
+      props: { posts: filteredPosts },
+    };
+  });
 }
 
 const { tag } = Astro.params;
 const { posts } = Astro.props;
-
-console.log(posts);
-
-const filteredPosts = posts.filter((post) =>
-  post.frontmatter.tags?.includes(tag)
-);
 ---
 
 <BaseLayout pageTitle={tag}>
   <p>Posts tagged with {tag}</p>
   <ul>
     {
-      filteredPosts.map((post) => (
-        <li>
-          <a href={post.url}>{post.frontmatter.title}</a>
-        </li>
+      posts.map((post) => (
+        <BlogPost url={post.url} title={post.frontmatter.title} />
       ))
     }
   </ul>


### PR DESCRIPTION
•  Refactored tag filtering logic in `getStaticPaths` to dynamically generate unique tags and filter posts accordingly.
•  Replaced inline post rendering with `BlogPost` component for better code reuse and readability.

Part of Astro Tutorial Build a Blog: Advanced JavaScript: Generate pages from existing tags
-> https://docs.astro.build/en/tutorial/5-astro-api/2/#advanced-javascript-generate-pages-from-existing-tags

commit-id:abc11257