### PR TITLE
refactor: update tags format in blog posts

### DIFF
--- a/src/pages/posts/post-1.md
+++ b/src/pages/posts/post-1.md
@@ -7,7 +7,7 @@ author: "Astro Learner"
 image:
   url: "https://docs.astro.build/assets/rose.webp"
   alt: "The Astro logo on a dark background with a pink glow."
-tags: ["astro", "blogging", "learning in public"]
+tags: ["astro", "blogging", "learning-in-public"]
 ---
 
 Welcome to my _new blog_ about learning Astro! Here, I will share my learning journey as I build a new website.

--- a/src/pages/posts/post-2.md
+++ b/src/pages/posts/post-2.md
@@ -7,7 +7,7 @@ image:
   url: "https://docs.astro.build/assets/arc.webp"
   alt: "The Astro logo on a dark background with a purple gradient arc."
 pubDate: 2022-07-08
-tags: ["astro", "blogging", "learning in public", "successes"]
+tags: ["astro", "blogging", "learning-in-public", "successes"]
 ---
 
 After a successful first week learning Astro, I decided to try some more. I wrote and imported a small component from memory!

--- a/src/pages/posts/post-3.md
+++ b/src/pages/posts/post-3.md
@@ -7,7 +7,7 @@ image:
   url: "https://docs.astro.build/assets/rays.webp"
   alt: "The Astro logo on a dark background with rainbow rays."
 pubDate: 2022-07-15
-tags: ["astro", "learning in public", "setbacks", "community"]
+tags: ["astro", "learning-in-public", "setbacks", "community"]
 ---
 
 It wasn't always smooth sailing, but I'm enjoying building with Astro. And, the [Discord community](https://astro.build/chat) is really friendly and helpful!


### PR DESCRIPTION
•  Updated tags format in `post-1.md`, `post-2.md`, and `post-3.md` to use hyphens instead of spaces.

---

**Stack**:
- #31
- #30 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*