### PR TITLE
feat: add tag index page

### DIFF
--- a/src/pages/posts/post-1.md
+++ b/src/pages/posts/post-1.md
@@ -7,7 +7,7 @@ author: "Astro Learner"
 image:
   url: "https://docs.astro.build/assets/rose.webp"
   alt: "The Astro logo on a dark background with a pink glow."
-tags: ["astro", "blogging", "learning in public"]
+tags: ["astro", "blogging", "learning-in-public"]
 ---
 
 Welcome to my _new blog_ about learning Astro! Here, I will share my learning journey as I build a new website.

--- a/src/pages/posts/post-2.md
+++ b/src/pages/posts/post-2.md
@@ -7,7 +7,7 @@ image:
   url: "https://docs.astro.build/assets/arc.webp"
   alt: "The Astro logo on a dark background with a purple gradient arc."
 pubDate: 2022-07-08
-tags: ["astro", "blogging", "learning in public", "successes"]
+tags: ["astro", "blogging", "learning-in-public", "successes"]
 ---
 
 After a successful first week learning Astro, I decided to try some more. I wrote and imported a small component from memory!

--- a/src/pages/posts/post-3.md
+++ b/src/pages/posts/post-3.md
@@ -7,7 +7,7 @@ image:
   url: "https://docs.astro.build/assets/rays.webp"
   alt: "The Astro logo on a dark background with rainbow rays."
 pubDate: 2022-07-15
-tags: ["astro", "learning in public", "setbacks", "community"]
+tags: ["astro", "learning-in-public", "setbacks", "community"]
 ---
 
 It wasn't always smooth sailing, but I'm enjoying building with Astro. And, the [Discord community](https://astro.build/chat) is really friendly and helpful!

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,44 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+export const prerender = true; // to prerender the page as static HTML during the build process.
+
+const allPosts = await Astro.glob("../posts/*.md");
+const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
+const pageTitle = "Tag Index";
+---
+
+<BaseLayout title={pageTitle}>
+  <h2>Tags</h2>
+  <div class="tags">
+    {
+      tags.map((tag) => {
+        return (
+          <p class="tag">
+            <a href={`/tags/${tag}`}>{tag}</a>
+          </p>
+        );
+      })
+    }
+  </div>
+</BaseLayout>
+
+<style>
+  a {
+    color: #00539f;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    margin: 0.25em;
+    border: dotted 1px #a1a1a1;
+    border-radius: 0.5em;
+    padding: 0.5em 1em;
+    font-size: 1.15em;
+    background-color: #f8fcfd;
+  }
+</style>


### PR DESCRIPTION
Created `index.astro` in the `tags` directory to display a list of tags with links to their respective pages.

Part of Astro Tutorial:
- Create an array of tags (https://docs.astro.build/en/tutorial/5-astro-api/3/#create-an-array-of-tags)
- Create your list of tags (https://docs.astro.build/en/tutorial/5-astro-api/3/#create-your-list-of-tags)
- Add styles to your tag list (https://docs.astro.build/en/tutorial/5-astro-api/3/#add-styles-to-your-tag-list)

commit-id:77ae3873

---

**Stack**:
- #31 ⬅
- #30


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*