### PR TITLE
feat: add tags link to navigation and display tags in posts

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -6,4 +6,5 @@
   <a href="/">Home</a>
   <a href="/about/">About</a>
   <a href="/blog/">Blog</a>
+  <a href="/tags/">Tags</a>
 </div>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -11,5 +11,35 @@ const { frontmatter } = Astro.props;
   <p>Written by: {frontmatter.author}</p>
   <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
 
+  <div class="tags">
+    {
+      frontmatter.tags.map((tag) => (
+        <p class="tag">
+          <a href={`/tags/${tag}`}>{tag}</a>
+        </p>
+      ))
+    }
+  </div>
+
   <slot />
 </BaseLayout>
+
+<style>
+  a {
+    color: #00539f;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    margin: 0.25em;
+    border: dotted 1px #a1a1a1;
+    border-radius: 0.5em;
+    padding: 0.5em 1em;
+    font-size: 1.15em;
+    background-color: #f8fcfd;
+  }
+</style>


### PR DESCRIPTION
- Added a "Tags" link to the navigation bar
- Updated the MarkdownPostLayout to display tags for each post.

Part of Astro Tutorial: Build a Blog with Astro and Markdown
- (https://docs.astro.build/en/tutorial/5-astro-api/3/#add-this-page-to-your-navigation)
- (https://docs.astro.build/en/tutorial/5-astro-api/3/#challenge-include-tags-in-your-blog-post-layout)

commit-id:19a4ab7d