### PR TITLE
feat(content): add content collection schema

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,22 @@
+// To learn about it: [Content Collection - Defining schema](https://docs.astro.build/en/guides/content-collections/#defining-a-collection-schema)
+
+import { defineCollection, z } from "astro:content";
+
+const postCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.date(),
+    description: z.string(),
+    author: z.string(),
+    image: z.object({
+      url: z.string(),
+      alt: z.string(),
+    }),
+    tags: z.array(z.string()),
+  }),
+});
+
+export const collections = {
+  posts: postCollection,
+};


### PR DESCRIPTION
•  Add `src/content/config.ts` to define a content collection schema

•  Use `astro:content` to define the collection and schema

•  Include fields for title, pubDate, description, author, image, and tags

---

**Stack**:
- #49
- #48
- #47
- #46
- #45 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*