### PR TITLE
fix(tags): update paths for post globbing (temporal)

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,7 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 export const prerender = true;
 // export const prerender = import.meta.env.PROD; <-- This is Deprecate since Astro 4.14
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob("../posts/*.md");
+  const allPosts = await Astro.glob("../../content/posts/*.md");
   const uniqueTags = [
     ...new Set(allPosts.map((post) => post.frontmatter.tags).flat()),
   ];

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export const prerender = true; // to prerender the page as static HTML during the build process.
 
-const allPosts = await Astro.glob("../posts/*.md");
+const allPosts = await Astro.glob("../../content/posts/*.md");
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---


### PR DESCRIPTION
•  Modify `src/pages/tags/[tag].astro` to update the path for post globbing

•  Modify `src/pages/tags/index.astro` to update the path for post globbing

---

**Stack**:
- #49
- #48
- #47 ⬅
- #46
- #45


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*