### PR TITLE
refactor: remove layout field from blog posts

### DIFF
--- a/src/content/posts/post-1.md
+++ b/src/content/posts/post-1.md
@@ -1,5 +1,4 @@
 ---
-layout: "../../layouts/MarkdownPostLayout.astro"
 title: "Astro A New Way"
 pubDate: 2022-07-01
 description: "This is the first post of my new Astro blog."

--- a/src/content/posts/post-2.md
+++ b/src/content/posts/post-2.md
@@ -1,5 +1,4 @@
 ---
-layout: "../../layouts/MarkdownPostLayout.astro"
 title: "Astro Another Try"
 author: "Astro Learner"
 description: "After learning some Astro, I couldn't stop!"

--- a/src/content/posts/post-3.md
+++ b/src/content/posts/post-3.md
@@ -1,5 +1,4 @@
 ---
-layout: "../../layouts/MarkdownPostLayout.astro"
 title: "Astro A Good Way of Building"
 author: "Astro Learner"
 description: "I had some challenges, but asking in the community really helped!"

--- a/src/content/posts/post-4.md
+++ b/src/content/posts/post-4.md
@@ -1,5 +1,4 @@
 ---
-layout: ../../layouts/MarkdownPostLayout.astro
 title: My Fourth Blog Post
 author: Astro Learner
 description: "This post will show up on its own!"


### PR DESCRIPTION
•  Modify `src/content/posts/post-1.md` to remove the `layout` field

•  Modify `src/content/posts/post-2.md` to remove the `layout` field

•  Modify `src/content/posts/post-3.md` to remove the `layout` field

•  Modify `src/content/posts/post-4.md` to remove the `layout` field

---

**Stack**:
- #49
- #48 ⬅
- #47
- #46
- #45


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*