### PR TITLE
refactor: update blog and tags pages to use getCollection

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,9 +1,10 @@
 ---
+import { getCollection } from "astro:content";
 import BlogPost from "../components/BlogPost.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/global.css";
 
-const allPost = await Astro.glob("../content/posts/*.md");
+const allPost = await getCollection("posts")
 const pageTitle = "“My Astro Learning Blog”";
 ---
 
@@ -12,7 +13,7 @@ const pageTitle = "“My Astro Learning Blog”";
   <ul>
     {
       allPost.map((post) => (
-        <BlogPost url={post.url} title={post.frontmatter.title} />
+        <BlogPost url={`/posts/${post.slug}`} title={post.data.title} />
       ))
     }
   </ul>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,17 +1,18 @@
 ---
+import { getCollection } from "astro:content";
 import BlogPost from "../../components/BlogPost.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 export const prerender = true;
 // export const prerender = import.meta.env.PROD; <-- This is Deprecate since Astro 4.14
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob("../../content/posts/*.md");
+  const allPosts = await getCollection("posts");
   const uniqueTags = [
-    ...new Set(allPosts.map((post) => post.frontmatter.tags).flat()),
+    ...new Set(allPosts.map((post) => post.data.tags).flat()),
   ];
 
   return uniqueTags.map((tag) => {
     const filteredPosts = allPosts.filter((post) =>
-      post.frontmatter.tags?.includes(tag)
+      post.data.tags?.includes(tag)
     );
     return {
       params: { tag },
@@ -29,7 +30,7 @@ const { posts } = Astro.props;
   <ul>
     {
       posts.map((post) => (
-        <BlogPost url={post.url} title={post.frontmatter.title} />
+        <BlogPost url={`/posts/${post.slug}`} title={post.data.title} />
       ))
     }
   </ul>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,10 +1,11 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export const prerender = true; // to prerender the page as static HTML during the build process.
 
-const allPosts = await Astro.glob("../../content/posts/*.md");
-const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
+const allPosts = await getCollection("posts");
+const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
 const pageTitle = "Tag Index";
 ---
 


### PR DESCRIPTION
•  Modify `src/pages/blog.astro` to use `getCollection` for fetching posts

•  Update `src/pages/tags/[tag].astro` to use `getCollection` and adjust tag filtering

•  Change `src/pages/tags/index.astro` to use `getCollection` for fetching posts and tags

---

**Stack**:
- #53
- #52
- #51 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*