### PR TITLE
style: update link styles for light and dark modes

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ const happy = true;
 const finished = true;
 const goal = 3;
 
-const skillColor = "navy";
+const skillColor = "#5c5cb6";
 const fontWeight = "bold";
 const textCase = "uppercase";
 ---

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,9 +1,10 @@
 ---
+import { getCollection } from "astro:content";
 import BlogPost from "../components/BlogPost.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/global.css";
 
-const allPost = await Astro.glob("../content/posts/*.md");
+const allPost = await getCollection("posts")
 const pageTitle = "“My Astro Learning Blog”";
 ---
 
@@ -12,7 +13,7 @@ const pageTitle = "“My Astro Learning Blog”";
   <ul>
     {
       allPost.map((post) => (
-        <BlogPost url={post.url} title={post.frontmatter.title} />
+        <BlogPost url={`/posts/${post.slug}`} title={post.data.title} />
       ))
     }
   </ul>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,17 +1,18 @@
 ---
+import { getCollection } from "astro:content";
 import BlogPost from "../../components/BlogPost.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 export const prerender = true;
 // export const prerender = import.meta.env.PROD; <-- This is Deprecate since Astro 4.14
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob("../../content/posts/*.md");
+  const allPosts = await getCollection("posts");
   const uniqueTags = [
-    ...new Set(allPosts.map((post) => post.frontmatter.tags).flat()),
+    ...new Set(allPosts.map((post) => post.data.tags).flat()),
   ];
 
   return uniqueTags.map((tag) => {
     const filteredPosts = allPosts.filter((post) =>
-      post.frontmatter.tags?.includes(tag)
+      post.data.tags?.includes(tag)
     );
     return {
       params: { tag },
@@ -29,7 +30,7 @@ const { posts } = Astro.props;
   <ul>
     {
       posts.map((post) => (
-        <BlogPost url={post.url} title={post.frontmatter.title} />
+        <BlogPost url={`/posts/${post.slug}`} title={post.data.title} />
       ))
     }
   </ul>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,10 +1,11 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export const prerender = true; // to prerender the page as static HTML during the build process.
 
-const allPosts = await Astro.glob("../../content/posts/*.md");
-const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
+const allPosts = await getCollection("posts");
+const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
 const pageTitle = "Tag Index";
 ---
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,11 @@
 html {
-  background-color: #f1f5f9;
+  background-color: #b4d2ef;
   font-family: sans-serif;
 }
 
 /* dark mode style */
 html.dark {
-  background-color: #0d0950;
+  background-color: #1f1e32;
   color: #fff;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,6 +73,22 @@ h1 {
   display: unset;
 }
 
+/* Link Styles */
+a {
+  color: #5c5cb6; /* Matches the skillColor from about.astro */
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+a:hover {
+  color: #1f1e32; /* Darker color for hover effect */
+  text-decoration: none;
+}
+html.dark a:hover {
+  color: #b4d2ef; /* Darker color for hover effect */
+  text-decoration: none;
+}
+
 @media screen and (min-width: 636px) {
   .nav-links {
     margin-left: 5em;


### PR DESCRIPTION
Modify `src/styles/global.css` to add custom link styles:
•  Set link color to `#5c5cb6` and underline text decoration

•  Change hover color to `#1f1e32` with no text decoration

•  Adjust dark mode hover color to `#b4d2ef` with no text decoration

commit-id:bc83e16b

---

**Stack**:
- #53 ⬅
- #52
- #51


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*